### PR TITLE
feat: -M option

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -32,6 +32,10 @@ export default yargs(process.argv.slice(2))
       describe: 'Set "from" 1 month',
       type: "boolean",
     },
+    M: {
+      alias: "specify-month",
+      describe: "Set the month to be counted (but only this year)",
+    },
     w: {
       alias: "week",
       describe: 'Set "from" 1 week',

--- a/lib/check-stats-modules.js
+++ b/lib/check-stats-modules.js
@@ -18,19 +18,10 @@ export default () => {
   const stats = [];
   let total = 0;
 
-  if (`${new Date(start)}` === "Invalid Date") {
-    showHelp(start);
-    return;
-  }
-  if (`${new Date(end)}` === "Invalid Date") {
-    showHelp(end);
-    return;
-  }
-
   // start date > end date
   if (new Date(start).getTime() > new Date(end).getTime()) {
-    showHelp("The start date is specified to be later than the end date. \n\n");
-    return;
+    console.log("＼( 'ω')／ウオオオオオアアアーーーッ！");
+    showHelp("The start date is specified to be later than the end date. \n");
   }
 
   for (const mod of args._) {

--- a/lib/check-stats-modules.js
+++ b/lib/check-stats-modules.js
@@ -20,7 +20,6 @@ export default () => {
 
   // start date > end date
   if (new Date(start).getTime() > new Date(end).getTime()) {
-    console.log("＼( 'ω')／ウオオオオオアアアーーーッ！");
     showHelp("The start date is specified to be later than the end date. \n");
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,4 +104,41 @@ const compare = (a, b) => {
   return 0;
 };
 
-export { showHelp, getStartDate, getEndDate, compare };
+/**
+ * Checks if the given string is a valid month name or its 3-letter abbreviation.
+ * The month names and abbreviations are case-insensitive.
+ *
+ * @param   {string} str - The input string to check.
+ * @returns {boolean} - Returns true if the input is a valid month name or abbreviation, false otherwise.
+ *
+ * @example
+ * isMonthName('January');  // true
+ * isMonthName('jan');      // true
+ * isMonthName('Octob');    // false
+ */
+const isMonthName = (str) => {
+  if (str === undefined || typeof str !== 'string') {
+    return false;
+  }
+
+  const months = [
+    'january', 'jan',
+    'february', 'feb',
+    'march', 'mar',
+    'april', 'apr',
+    'may',
+    'june', 'jun',
+    'july', 'jul',
+    'august', 'aug',
+    'september', 'sep',
+    'october', 'oct',
+    'november', 'nov',
+    'december', 'dec'
+  ];
+
+  const lowerCaseInput = str.toLowerCase();
+
+  return months.includes(lowerCaseInput);
+}
+
+export { showHelp, getStartDate, getEndDate, compare, isMonthName };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,4 @@
 import chalk from "chalk";
-import yargs from "yargs";
 import {
   format,
   parseISO,
@@ -9,7 +8,11 @@ import {
   addMonths,
   addYears,
   getYear,
+  startOfMonth,
+  endOfMonth,
 } from "date-fns";
+
+const FORMAT_DATE = "yyyy-MM-dd";
 
 /**
  * show help
@@ -18,8 +21,10 @@ import {
  * @return {String} full help message
  */
 const showHelp = (text) => {
-  if (text) console.log(chalk.yellow.bold(text));
-  yargs(process.argv.slice(2)).showHelp();
+  console.error(
+    `${chalk.yellow.bold(text)}run "csm --help" for usage information`,
+  );
+  process.exit(1);
 };
 
 /**
@@ -31,30 +36,33 @@ const showHelp = (text) => {
 const getStartDate = (args) => {
   // check module names
   if (args._.length === 0) {
-    return "Please enter the module names at least one. \n";
+    showHelp("Please enter the module names at least one. \n");
   }
   // check start date options
   if (args.s) {
     if (!/\d{4}-\d{2}-\d{2}/.test(args.s)) {
-      return "Please enter the date correctly. \n";
+      showHelp("Please enter the date correctly. \n");
     }
     if (!isValid(parseISO(args.s))) {
-      return "Please enter the date correctly. \n";
+      showHelp("Please enter the date correctly. \n");
     }
   }
   if (args.m) {
-    return format(addMonths(new Date(), -1), "yyyy-MM-dd");
+    return format(addMonths(new Date(), -1), FORMAT_DATE);
+  }
+  if (args.M) {
+    return getMonthBounds(args.M, "start");
   }
   if (args.y) {
-    return format(addYears(new Date(), -1), "yyyy-MM-dd");
+    return format(addYears(new Date(), -1), FORMAT_DATE);
   }
   if (args.t) {
     return `${getYear(new Date())}-01-01`;
   }
   if (args.w) {
-    return format(addWeeks(new Date(), -1), "yyyy-MM-dd");
+    return format(addWeeks(new Date(), -1), FORMAT_DATE);
   }
-  return args.s || format(addDays(new Date(), -1), "yyyy-MM-dd");
+  return args.s || format(addDays(new Date(), -1), FORMAT_DATE);
 };
 
 /**
@@ -66,24 +74,30 @@ const getStartDate = (args) => {
 const getEndDate = (args) => {
   // check module names
   if (args._.length === 0) {
-    return "Please enter the module names at least one. \n";
+    showHelp("Please enter the module names at least one. \n");
   }
   if (!args.s && args.e) {
-    return "Please enter the start date. \nBecause when using -s option, then start date is required. \n";
-  }
-  if (!args.e || Object.keys(args).length === 2) {
-    return format(new Date(), "yyyy-MM-dd");
+    showHelp(
+      "Please enter the start date. \nBecause when using -s option, then start date is required. \n",
+    );
   }
   // check end date options
   if (args.e) {
     if (!/\d{4}-\d{2}-\d{2}/.test(args.e)) {
-      return "Please enter the date correctly. \n";
+      showHelp("Please enter the date correctly. \n");
     }
     if (!isValid(parseISO(args.e))) {
-      return "Please enter the date correctly. \n";
+      showHelp("Please enter the date correctly. \n");
     }
   }
-  return args.e || format(new Date(), "yyyy-MM-dd");
+  if (Object.keys(args).length === 2) {
+    return format(new Date(), FORMAT_DATE);
+  }
+  if (args.M) {
+    return getMonthBounds(args.M, "end");
+  }
+
+  return args.e || format(new Date(), FORMAT_DATE);
 };
 
 /**
@@ -117,28 +131,111 @@ const compare = (a, b) => {
  * isMonthName('Octob');    // false
  */
 const isMonthName = (str) => {
-  if (str === undefined || typeof str !== 'string') {
+  if (str === undefined || typeof str !== "string") {
     return false;
   }
 
   const months = [
-    'january', 'jan',
-    'february', 'feb',
-    'march', 'mar',
-    'april', 'apr',
-    'may',
-    'june', 'jun',
-    'july', 'jul',
-    'august', 'aug',
-    'september', 'sep',
-    'october', 'oct',
-    'november', 'nov',
-    'december', 'dec'
+    "january",
+    "jan",
+    "february",
+    "feb",
+    "march",
+    "mar",
+    "april",
+    "apr",
+    "may",
+    "june",
+    "jun",
+    "july",
+    "jul",
+    "august",
+    "aug",
+    "september",
+    "sep",
+    "october",
+    "oct",
+    "november",
+    "nov",
+    "december",
+    "dec",
   ];
 
   const lowerCaseInput = str.toLowerCase();
 
   return months.includes(lowerCaseInput);
-}
+};
 
-export { showHelp, getStartDate, getEndDate, compare, isMonthName };
+/**
+ * Gets the first and last days of the given month.
+ *
+ * @param {string} str - The input string representing the month.
+ * @param {string} type - The type of day to retrieve ('start' or 'end').
+ * @returns {Object|null} - Returns an object with the first and last days of the month, or null if the str is invalid.
+ *
+ * @example
+ * getMonthDay('January', 'start');  // '2023-01-01'
+ * getMonthDay('jan', 'end');       // '2023-01-31'
+ * getMonthDay('Feb', 'start');      // '2023-02-01'
+ */
+const getMonthBounds = (str, type) => {
+  if (typeof str !== "string") {
+    showHelp("Please enter the Month correctly. \n");
+  }
+  if (type !== "start" && type !== "end") {
+    console.error(
+      chalk.red.bold(
+        "Unexpected error: Something went wrong. Please report this issue.\n",
+      ),
+    );
+    process.exit(1);
+  }
+
+  // Convert the str to a full month name
+  const monthNames = {
+    jan: "january",
+    feb: "february",
+    mar: "march",
+    apr: "april",
+    may: "may",
+    jun: "june",
+    jul: "july",
+    aug: "august",
+    sep: "september",
+    oct: "october",
+    nov: "november",
+    dec: "december",
+  };
+
+  let fullMonthName = str.toLowerCase();
+  if (fullMonthName.length === 3) {
+    fullMonthName = monthNames[fullMonthName];
+  }
+  if (!isMonthName(fullMonthName)) {
+    showHelp("Please enter the Month correctly. \n");
+  }
+
+  const currentYear = new Date().getFullYear();
+  const dateStr = `${fullMonthName} 1, ${currentYear}`;
+  const date = new Date(dateStr);
+
+  if (!isValid(date)) {
+    showHelp("Please enter the Month correctly. \n");
+  }
+
+  if (type === "start") {
+    return format(startOfMonth(date), FORMAT_DATE);
+  }
+  if (type === "end") {
+    return format(endOfMonth(date), FORMAT_DATE);
+  }
+};
+
+export {
+  showHelp,
+  getStartDate,
+  getEndDate,
+  compare,
+  isMonthName,
+  getMonthBounds,
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,9 +90,6 @@ const getEndDate = (args) => {
       showHelp("Please enter the date correctly. \n");
     }
   }
-  if (Object.keys(args).length === 2) {
-    return format(new Date(), FORMAT_DATE);
-  }
   if (args.M) {
     return getMonthBounds(args.M, "end");
   }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "date-fns": "^3.0.0",
+    "date-fns-tz": "^3.1.3",
     "json-table": "^0.1.3",
     "npm-stats-api": "^2.0.2",
     "yargs": "^17.7.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   date-fns:
     specifier: ^3.0.0
     version: 3.6.0
+  date-fns-tz:
+    specifier: ^3.1.3
+    version: 3.1.3(date-fns@3.6.0)
   json-table:
     specifier: ^0.1.3
     version: 0.1.3
@@ -1154,6 +1157,14 @@ packages:
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
+
+  /date-fns-tz@3.1.3(date-fns@3.6.0):
+    resolution: {integrity: sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==}
+    peerDependencies:
+      date-fns: ^3.0.0
+    dependencies:
+      date-fns: 3.6.0
+    dev: false
 
   /date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,13 @@
-import { getStartDate, getEndDate, compare, isMonthName } from "../lib/utils.js";
+import { jest } from "@jest/globals";
+import chalk from "chalk";
+import { isLeapYear } from "date-fns";
+import {
+  getStartDate,
+  getEndDate,
+  compare,
+  isMonthName,
+  getMonthBounds,
+} from "../lib/utils.js";
 
 const date = String(new Date().getDate());
 const month = String(new Date().getMonth());
@@ -7,75 +16,184 @@ const todayMonth = month.length === 2 ? month : `0${month}`;
 const yesterdayDate = date.length === 2 ? String(date - 1) : `0${date - 1}`;
 
 const errorMessages = {
-  dateFormatError: "Please enter the date correctly. \n",
-  moduleNameNull: "Please enter the module names at least one. \n",
-  notSpecifiedOption:
+  dateFormatError: chalk.yellow.bold("Please enter the date correctly. \n"),
+  moduleNameNull: chalk.yellow.bold(
+    "Please enter the module names at least one. \n",
+  ),
+  notSpecifiedOption: chalk.yellow.bold(
     "Please enter the start date. \nBecause when using -s option, then start date is required. \n",
+  ),
+  startLaterThanEnd: chalk.yellow.bold(
+    "The start date is specified to be later than the end date. \n",
+  ),
+  invalidMonth: chalk.yellow.bold("Please enter the Month correctly. \n"),
+  invalidType: chalk.red.bold(
+    "Unexpected error: Something went wrong. Please report this issue.\n",
+  ),
 };
+const helpMessage = `run "csm --help" for usage information`;
+
+const mockConsoleError = jest
+  .spyOn(console, "error")
+  .mockImplementation(() => {});
+const mockExit = jest.spyOn(process, "exit").mockImplementation(() => {
+  throw new Error("process.exit called");
+});
+
+afterAll(() => {
+  mockConsoleError.mockRestore();
+  mockExit.mockRestore();
+});
 
 // As these options are only processing of external libraries, check only one
 // 'week', 'month', 'year'
-test.concurrent("check start date when -m option", async () => {
-  const argsStub = {
-    s: false,
-    e: false,
-    m: true,
-    y: false,
-    t: false,
-    w: false,
-    _: ["check-stats-modules"],
-  };
-
-  const actual = await getStartDate(argsStub);
-
-  expect(typeof actual).toBe("string");
-  expect(actual.length).toBe(10);
-  expect(actual.split("-")[1]).toBe(todayMonth);
-});
-
-test.concurrent("check start date when -t option", async () => {
-  const argsStub = {
-    s: false,
-    e: false,
-    m: false,
-    y: false,
-    t: true,
-    w: false,
-    _: ["check-stats-modules"],
-  };
-  const actual = await getStartDate(argsStub);
-
-  expect(typeof actual).toBe("string");
-  expect(actual.length).toBe(10);
-  expect(actual.split("-")[1]).toBe("01");
-  expect(actual.split("-")[2]).toBe("01");
-});
-
-test.concurrent(
-  "check start date when specify correct date with -s option",
-  async (t) => {
+describe("-m option tests", () => {
+  test.concurrent("check start date when -m option", () => {
     const argsStub = {
-      s: "2018-05-03",
+      s: false,
       e: false,
-      m: false,
+      m: true,
       y: false,
       t: false,
       w: false,
       _: ["check-stats-modules"],
     };
-    const actual = await getStartDate(argsStub);
+
+    const actual = getStartDate(argsStub);
 
     expect(typeof actual).toBe("string");
     expect(actual.length).toBe(10);
-    expect(actual).toBe(argsStub.s);
-  }
-);
+    expect(actual.split("-")[1]).toBe(todayMonth);
+  });
+});
 
-test.concurrent(
-  "check start date when specify empty string with -s option",
-  async () => {
+describe("-t option tests", () => {
+  test.concurrent("check start date when -t option", () => {
     const argsStub = {
-      s: "",
+      s: false,
+      e: false,
+      m: false,
+      y: false,
+      t: true,
+      w: false,
+      _: ["check-stats-modules"],
+    };
+    const actual = getStartDate(argsStub);
+
+    expect(typeof actual).toBe("string");
+    expect(actual.length).toBe(10);
+    expect(actual.split("-")[1]).toBe("01");
+    expect(actual.split("-")[2]).toBe("01");
+  });
+});
+
+describe("-s option tests", () => {
+  test.concurrent(
+    "check start date when specify correct date with -s option",
+    () => {
+      const argsStub = {
+        s: "2018-05-03",
+        e: false,
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
+      const actual = getStartDate(argsStub);
+
+      expect(typeof actual).toBe("string");
+      expect(actual.length).toBe(10);
+      expect(actual).toBe(argsStub.s);
+    },
+  );
+
+  test.concurrent(
+    "check start date when specify empty string with -s option",
+    () => {
+      const argsStub = {
+        s: "",
+        e: false,
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
+      const actual = getStartDate(argsStub);
+
+      expect(typeof actual).toBe("string");
+      expect(actual.length).toBe(10);
+      expect(actual.split("-")[2]).toBe(yesterdayDate);
+    },
+  );
+
+  test.concurrent(
+    "check start date when specify incorrect date with -s option",
+    () => {
+      const argsStub = {
+        s: "2018-",
+        e: false,
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
+
+      expect(() => getStartDate(argsStub)).toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.dateFormatError + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
+
+  test.concurrent(
+    "check start date when specify not exist date with -s option",
+    () => {
+      const argsStub = {
+        s: "2018-15-89",
+        e: false,
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
+
+      expect(() => getStartDate(argsStub)).toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.dateFormatError + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
+
+  test.concurrent(
+    "check start date when specify symbols with -s option",
+    () => {
+      const argsStub = {
+        s: '!"#$%&()',
+        e: false,
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
+
+      expect(() => getStartDate(argsStub)).toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.dateFormatError + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
+
+  test.concurrent("check start date when specify with no options", () => {
+    const argsStub = {
+      s: false,
       e: false,
       m: false,
       y: false,
@@ -83,299 +201,351 @@ test.concurrent(
       w: false,
       _: ["check-stats-modules"],
     };
-    const actual = await getStartDate(argsStub);
+    const actual = getStartDate(argsStub);
 
     expect(typeof actual).toBe("string");
     expect(actual.length).toBe(10);
     expect(actual.split("-")[2]).toBe(yesterdayDate);
-  }
-);
-
-test.concurrent(
-  "check start date when specify incorrect da with -s option",
-  async () => {
-    const argsStub = {
-      s: "2018-",
-      e: false,
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
-    const error = await getStartDate(argsStub);
-
-    expect(error).toBe(errorMessages.dateFormatError);
-  }
-);
-
-test.concurrent(
-  "check start date when specify not exist da with -s option",
-  async () => {
-    const argsStub = {
-      s: "2018-15-89",
-      e: false,
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
-
-    const error = await getStartDate(argsStub);
-
-    expect(error).toBe(errorMessages.dateFormatError);
-  }
-);
-
-test.concurrent(
-  "check start date when specify symbols with -s option",
-  async () => {
-    const argsStub = {
-      s: '!"#$%&()',
-      e: false,
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
-
-    const error = await getStartDate(argsStub);
-
-    expect(error).toBe(errorMessages.dateFormatError);
-  }
-);
-
-test.concurrent("check start date when specify with no options", async () => {
-  const argsStub = {
-    s: false,
-    e: false,
-    m: false,
-    y: false,
-    t: false,
-    w: false,
-    _: ["check-stats-modules"],
-  };
-  const actual = await getStartDate(argsStub);
-
-  expect(typeof actual).toBe("string");
-  expect(actual.length).toBe(10);
-  expect(actual.split("-")[2]).toBe(yesterdayDate);
+  });
 });
 
-test.concurrent(
-  "check end date when specify correct date with -s and -e option",
-  async () => {
-    const argsStub = {
-      s: "2018-05-03",
-      e: "2019-12-08",
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
-    const actual = await getEndDate(argsStub);
+describe("-s and -e option tests", () => {
+  test.concurrent(
+    "check end date when specify correct date with -s and -e option",
+    () => {
+      const argsStub = {
+        s: "2018-05-03",
+        e: "2019-12-08",
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
+      const actual = getEndDate(argsStub);
 
-    expect(typeof actual).toBe("string");
-    expect(actual.length).toBe(10);
-    expect(actual === "2019-12-08");
-    expect(actual).toBe(argsStub.e);
-  }
-);
+      expect(typeof actual).toBe("string");
+      expect(actual.length).toBe(10);
+      expect(actual === "2019-12-08");
+      expect(actual).toBe(argsStub.e);
+    },
+  );
 
-test.concurrent(
-  "check end date when specify correct date with -s option, but specify empty string with -e option",
-  async () => {
-    const argsStub = {
-      s: "2018-05-03",
-      e: "",
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
-    const actual = await getEndDate(argsStub);
+  test.concurrent(
+    "check end date when specify correct date with -s option, but specify empty string with -e option",
+    () => {
+      const argsStub = {
+        s: "2018-05-03",
+        e: "",
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
+      const actual = getEndDate(argsStub);
 
-    expect(typeof actual).toBe("string");
-    expect(actual.length).toBe(10);
-    expect(actual.split("-")[2] === todayDate);
-  }
-);
+      expect(typeof actual).toBe("string");
+      expect(actual.length).toBe(10);
+      expect(actual.split("-")[2] === todayDate);
+    },
+  );
 
-test.concurrent(
-  "check start date when specify correct date with -s option, but specify incorrect date with -e option",
-  async () => {
-    const argsStub = {
-      s: "2018-05-03",
-      e: "2019-",
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
-    const error = await getEndDate(argsStub);
+  test.concurrent(
+    "check start date when specify correct date with -s option, but specify incorrect date with -e option",
+    () => {
+      const argsStub = {
+        s: "2018-05-03",
+        e: "2019-",
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
 
-    expect(error).toBe(errorMessages.dateFormatError);
-  }
-);
+      expect(() => getEndDate(argsStub)).toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.dateFormatError + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
 
-test.concurrent(
-  "check start date when specify correct date with -s option, but specify not exist date with -e option",
-  async () => {
-    const argsStub = {
-      s: "2018-05-03",
-      e: "2019-15-89",
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
+  test.concurrent(
+    "check start date when specify correct date with -s option, but specify not exist date with -e option",
+    () => {
+      const argsStub = {
+        s: "2018-05-03",
+        e: "2019-15-89",
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
 
-    const error = await getEndDate(argsStub);
+      expect(() => getEndDate(argsStub)).toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.dateFormatError + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
 
-    expect(error).toBe(errorMessages.dateFormatError);
-  }
-);
+  test.concurrent(
+    "check start date when does not specify -s option and specify correct date with -e option",
+    () => {
+      const argsStub = {
+        s: false,
+        e: "2019-12-08",
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
 
-test.concurrent(
-  "check start date when does not specify -s option and specify correct date with -e option",
-  async (t) => {
-    const argsStub = {
-      s: false,
-      e: "2019-12-08",
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
+      expect(() => getEndDate(argsStub)).toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.dateFormatError + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
 
-    const error = await getEndDate(argsStub);
+  test.concurrent(
+    "check start date when specify correct date with -s option, but specify symbols with -e option",
+    () => {
+      const argsStub = {
+        s: "2018-05-03",
+        e: '!"#$%&()',
+        m: false,
+        y: false,
+        t: false,
+        w: false,
+        _: ["check-stats-modules"],
+      };
 
-    expect(error).toBe(errorMessages.notSpecifiedOption);
-  }
-);
-
-test.concurrent(
-  "check start date when specify correct date with -s option, but specify symbols with -e option",
-  async (t) => {
-    const argsStub = {
-      s: "2018-05-03",
-      e: '!"#$%&()',
-      m: false,
-      y: false,
-      t: false,
-      w: false,
-      _: ["check-stats-modules"],
-    };
-
-    const error = await getEndDate(argsStub);
-
-    expect(error).toBe(errorMessages.dateFormatError);
-  }
-);
-
-test.concurrent("check when module name is not specified", async (t) => {
-  const argsStub = {
-    s: "2019-08-30",
-    e: false,
-    m: false,
-    y: false,
-    t: false,
-    w: false,
-    _: [],
-  };
-
-  const error = await getStartDate(argsStub);
-
-  expect(error).toBe(errorMessages.moduleNameNull);
+      expect(() => getEndDate(argsStub)).toThrow("process.exit called");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.dateFormatError + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
 });
 
-test.concurrent(
-  "check return value is 1 when the downloads of the first argument is greater than that of the second",
-  async (t) => {
-    const arg1 = {
-      downloads: 25,
-      start: "2020-08-20",
-      end: "2020-09-20",
-      package: "check-stats-modules",
-    };
-    const arg2 = {
-      downloads: 150,
-      start: "2020-08-20",
-      end: "2020-09-20",
-      package: "riot-barcode",
+describe("other test cases", () => {
+  test.concurrent("check when module name is not specified", () => {
+    const argsStub = {
+      s: "2019-08-30",
+      e: false,
+      m: false,
+      y: false,
+      t: false,
+      w: false,
+      _: [],
     };
 
-    const expected = 1;
-    const actual = compare(arg1, arg2);
+    expect(() => getStartDate(argsStub)).toThrow("process.exit called");
+    expect(mockConsoleError).toHaveBeenCalledWith(
+      errorMessages.dateFormatError + helpMessage,
+    );
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});
 
-    expect(expected).toBe(actual);
-  }
-);
+describe("compare function tests", () => {
+  test.concurrent(
+    "check return value is 1 when the downloads of the first argument is greater than that of the second",
+    () => {
+      const arg1 = {
+        downloads: 25,
+        start: "2020-08-20",
+        end: "2020-09-20",
+        package: "check-stats-modules",
+      };
+      const arg2 = {
+        downloads: 150,
+        start: "2020-08-20",
+        end: "2020-09-20",
+        package: "riot-barcode",
+      };
 
-test.concurrent(
-  "check return value is -1 when the downloads of the first argument is less than that of the second",
-  async (t) => {
-    const arg1 = {
-      downloads: 150,
-      start: "2020-08-20",
-      end: "2020-09-20",
-      package: "riot-barcode",
-    };
-    const arg2 = {
-      downloads: 25,
-      start: "2020-08-20",
-      end: "2020-09-20",
-      package: "check-stats-modules",
-    };
+      const expected = 1;
+      const actual = compare(arg1, arg2);
 
-    const expected = -1;
-    const actual = compare(arg1, arg2);
+      expect(expected).toBe(actual);
+    },
+  );
 
-    expect(expected).toBe(actual);
-  }
-);
+  test.concurrent(
+    "check return value is -1 when the downloads of the first argument is less than that of the second",
+    () => {
+      const arg1 = {
+        downloads: 150,
+        start: "2020-08-20",
+        end: "2020-09-20",
+        package: "riot-barcode",
+      };
+      const arg2 = {
+        downloads: 25,
+        start: "2020-08-20",
+        end: "2020-09-20",
+        package: "check-stats-modules",
+      };
 
-test.concurrent(
-  "check that true is returned when the -M option is specified",
-  async (t) => {
-     let argsStub = 'January';
-    let actual = await isMonthName(argsStub);
-    expect(actual).toBe(true);
+      const expected = -1;
+      const actual = compare(arg1, arg2);
 
-    argsStub = 'jan';
-    actual = await isMonthName(argsStub);
-    expect(actual).toBe(true);
+      expect(expected).toBe(actual);
+    },
+  );
+});
 
-    argsStub = 'Feb';
-    actual = await isMonthName(argsStub);
-    expect(actual).toBe(true);
+describe("isMonthName function tests", () => {
+  test.concurrent(
+    "check that true is returned when the -M option is specified",
+    () => {
+      let argsStub = "January";
+      let actual = isMonthName(argsStub);
+      expect(actual).toBe(true);
 
-    argsStub = 'DeCemBEr';
-    actual = await isMonthName(argsStub);
-    expect(actual).toBe(true);
-  }
-)
+      argsStub = "jan";
+      actual = isMonthName(argsStub);
+      expect(actual).toBe(true);
 
-test.concurrent(
-  "check that false is returned when the -M option is specified but the argument is not a month name",
-  async (t) => {
-    let argsStub = 'Januar';
-    let actual = await isMonthName(argsStub);
-    expect(actual).toBe(false);
+      argsStub = "Feb";
+      actual = isMonthName(argsStub);
+      expect(actual).toBe(true);
 
-    argsStub = 'xyz';
-    actual = await isMonthName(argsStub);
-    expect(actual).toBe(false);
+      argsStub = "DeCemBEr";
+      actual = isMonthName(argsStub);
+      expect(actual).toBe(true);
+    },
+  );
 
-    argsStub = true;
-    actual = await isMonthName(argsStub);
-    expect(actual).toBe(false);
-  }
-)
+  test.concurrent(
+    "check that false is returned when the -M option is specified but the argument is not a month name",
+    () => {
+      let argsStub = "Januar";
+      let actual = isMonthName(argsStub);
+      expect(actual).toBe(false);
+
+      argsStub = "xyz";
+      actual = isMonthName(argsStub);
+      expect(actual).toBe(false);
+
+      argsStub = true;
+      actual = isMonthName(argsStub);
+      expect(actual).toBe(false);
+
+      argsStub = "";
+      actual = isMonthName(argsStub);
+      expect(actual).toBe(false);
+    },
+  );
+});
+
+describe("getMonthBounds function tests", () => {
+  test.concurrent(
+    "check that the start and end dates of the month are returned when the -M option is specified",
+    () => {
+      let argsStub1 = "January";
+      let argsStub2 = "start";
+      let actual = getMonthBounds(argsStub1, argsStub2);
+      expect(actual).toBe(`${new Date().getFullYear()}-01-01`);
+
+      argsStub1 = "Feb";
+      argsStub2 = "end";
+      actual = getMonthBounds(argsStub1, argsStub2);
+      const tmpDate = new Date();
+      expect(actual).toBe(
+        `${tmpDate.getFullYear()}-02-${isLeapYear(tmpDate) ? 29 : 28}`,
+      );
+
+      argsStub1 = "DeCemBEr";
+      argsStub2 = "end";
+      actual = getMonthBounds(argsStub1, argsStub2);
+      expect(actual).toBe(`${new Date().getFullYear()}-12-31`);
+    },
+  );
+
+  test.concurrent(
+    "check the error message is returned when the -M option is specified but the argument is not a month name",
+    () => {
+      let monthStr = "Januar";
+      let type = "start";
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.invalidMonth + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      monthStr = "xyz";
+      type = "end";
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.invalidMonth + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      monthStr = true;
+      type = "start";
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.invalidMonth + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      monthStr = "";
+      type = "end";
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        errorMessages.invalidMonth + helpMessage,
+      );
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      monthStr = "AUgust";
+      type = "xyz";
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(errorMessages.invalidType);
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      monthStr = "June";
+      type = false;
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(errorMessages.invalidType);
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      monthStr = "NOVember";
+      type = undefined;
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(errorMessages.invalidType);
+      expect(mockExit).toHaveBeenCalledWith(1);
+
+      monthStr = "NOVember";
+      type = "";
+      expect(() => getMonthBounds(monthStr, type)).toThrow(
+        "process.exit called",
+      );
+      expect(mockConsoleError).toHaveBeenCalledWith(errorMessages.invalidType);
+      expect(mockExit).toHaveBeenCalledWith(1);
+    },
+  );
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,4 +1,4 @@
-import { getStartDate, getEndDate, compare } from "../lib/utils.js";
+import { getStartDate, getEndDate, compare, isMonthName } from "../lib/utils.js";
 
 const date = String(new Date().getDate());
 const month = String(new Date().getMonth());
@@ -341,3 +341,41 @@ test.concurrent(
     expect(expected).toBe(actual);
   }
 );
+
+test.concurrent(
+  "check that true is returned when the -M option is specified",
+  async (t) => {
+     let argsStub = 'January';
+    let actual = await isMonthName(argsStub);
+    expect(actual).toBe(true);
+
+    argsStub = 'jan';
+    actual = await isMonthName(argsStub);
+    expect(actual).toBe(true);
+
+    argsStub = 'Feb';
+    actual = await isMonthName(argsStub);
+    expect(actual).toBe(true);
+
+    argsStub = 'DeCemBEr';
+    actual = await isMonthName(argsStub);
+    expect(actual).toBe(true);
+  }
+)
+
+test.concurrent(
+  "check that false is returned when the -M option is specified but the argument is not a month name",
+  async (t) => {
+    let argsStub = 'Januar';
+    let actual = await isMonthName(argsStub);
+    expect(actual).toBe(false);
+
+    argsStub = 'xyz';
+    actual = await isMonthName(argsStub);
+    expect(actual).toBe(false);
+
+    argsStub = true;
+    actual = await isMonthName(argsStub);
+    expect(actual).toBe(false);
+  }
+)


### PR DESCRIPTION
# overview

Add new option `-M`
This option allows you to specify the full name of the month or the first three letters (e.g. `Jar`) to get the number of downloads from the first to the last day of the month.

## note 
* The case of the name of the month to be specified is not relevant
* Only the year in which the command is executed . For past cities, use the `-s` and `-e` options

## links

#77 